### PR TITLE
Update to Spark 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,27 @@
 name := "spark-indexedrdd"
-
-version := "0.3"
-
+version := "0.4.0"
 organization := "edu.berkeley.cs.amplab"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.8"
+crossScalaVersions := Seq("2.10.6", "2.11.6")
 
 spName := "amplab/spark-indexedrdd"
-
-sparkVersion := "1.5.0"
-
+sparkVersion := "2.1.0"
 sparkComponents += "core"
+
+resolvers += "Repo at github.com/ankurdave/maven-repo" at "https://raw.githubusercontent.com/ankurdave/maven-repo/master"
+
+libraryDependencies ++= Seq(
+  "com.ankurdave" % "part_2.10" % "0.1",  // artifact is not published for 2.11, but it only contains Java code anyway
+  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "org.scalacheck" %% "scalacheck" % "1.12.2" % "test"
+)
 
 publishMavenStyle := true
 
 licenses += "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")
 
-pomExtra := (
+pomExtra :=
   <url>https://github.com/amplab/spark-indexedrdd</url>
   <scm>
     <url>git@github.com:amplab/spark-indexedrdd.git</url>
@@ -28,15 +33,8 @@ pomExtra := (
       <name>Ankur Dave</name>
       <url>https://github.com/ankurdave</url>
     </developer>
-  </developers>)
+  </developers>
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4" % "test"
-
-libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.12.2" % "test"
-
-resolvers += "Repo at github.com/ankurdave/maven-repo" at "https://raw.githubusercontent.com/ankurdave/maven-repo/master"
-
-libraryDependencies += "com.ankurdave" %% "part" % "0.1"
 
 // Run tests with more memory
 javaOptions in test += "-Xmx2G"

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.6
+sbt.version=0.13.13

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
@@ -29,7 +29,7 @@ import edu.berkeley.cs.amplab.spark.indexedrdd.impl._
 /**
  * An RDD of key-value `(K, V)` pairs that pre-indexes the entries for fast lookups, joins, and
  * optionally updates. To construct an `IndexedRDD`, use one of the constructors in the
- * [[edu.berkeley.cs.amplab.spark.indexedrdd.IndexedRDD$ IndexedRDD object]].
+ * [[edu.berkeley.cs.amplab.spark.indexedrdd.IndexedRDD IndexedRDD object]].
  *
  * @tparam K the key associated with each entry in the set.
  * @tparam V the value associated with each entry in the set.

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/impl/PARTPartition.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/impl/PARTPartition.scala
@@ -20,10 +20,7 @@ package edu.berkeley.cs.amplab.spark.indexedrdd.impl
 import scala.reflect.ClassTag
 import scala.collection.JavaConversions._
 
-import org.apache.spark.Logging
-
 import edu.berkeley.cs.amplab.spark.indexedrdd._
-
 import com.ankurdave.part.ArtTree
 
 private[indexedrdd] class PARTPartition[K, V]
@@ -31,7 +28,7 @@ private[indexedrdd] class PARTPartition[K, V]
     (override implicit val kTag: ClassTag[K],
      override implicit val vTag: ClassTag[V],
      implicit val kSer: KeySerializer[K])
-  extends IndexedRDDPartition[K, V] with Logging {
+  extends IndexedRDDPartition[K, V] {
 
   protected def withMap[V2: ClassTag]
       (map: ArtTree): PARTPartition[K, V2] = {

--- a/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDSuite.scala
+++ b/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDSuite.scala
@@ -197,6 +197,12 @@ class UpdatableIndexedRDDSuite extends IndexedRDDSuite {
       Set(-1L -> -1, 0L -> 1) ++ (1 to n).map(x => (x.toLong, x)).toSet)
     assert(ps.multiput(Map(-1L -> -1, 0L -> 1, 1L -> 1)).collect.toSet ===
       Set(-1L -> -1, 0L -> 1, 1L -> 1) ++ (2 to n).map(x => (x.toLong, x)).toSet)
+    assert(ps.multiputRDD[Int](sc.parallelize(Seq(0L -> 1, 1L -> 1)), (id, a) => a, SumFunction).collect.toSet ===
+      Set(0L -> 1, 1L -> 2) ++ (2 to n).map(x => (x.toLong, x)).toSet)
+    assert(ps.multiputRDD[Int](sc.parallelize(Seq(-1L -> -1, 0L -> 1)), (id, a) => a, SumFunction).collect.toSet ===
+      Set(-1L -> -1, 0L -> 1) ++ (1 to n).map(x => (x.toLong, x)).toSet)
+    assert(ps.multiputRDD(sc.parallelize(Seq(-1L -> -1, 0L -> 1, 1L -> 1))).collect.toSet ===
+      Set(-1L -> -1, 0L -> 1, 1L -> 1) ++ (2 to n).map(x => (x.toLong, x)).toSet)
     assert(ps.put(-1L, -1).collect.toSet ===
       Set(-1L -> -1) ++ (0 to n).map(x => (x.toLong, x)).toSet)
     assert(ps.put(0L, 1).collect.toSet ===


### PR DESCRIPTION
* Spark version to 2.1.0
* Default Scala version to 2.11.8 (cross-build for 2.10.6)
* Added multiputRDD methods